### PR TITLE
Calculate and apply the instrument's tax rate percentage to transactions

### DIFF
--- a/src/DataFixtures/InstrumentFixture.php
+++ b/src/DataFixtures/InstrumentFixture.php
@@ -30,7 +30,7 @@ class InstrumentFixture extends Fixture implements DependentFixtureInterface
         $appl_inst->setEusipa(Instrument::EUSIPA_KNOCKOUT);
         $appl_inst->setCurrency("EUR");
         $appl_inst->setUnderlying($appl);
-        $appl_inst->setTaxRate(0.12);
+        $appl_inst->setExecutionTaxRate(0.0012); // 0.12 %
         $manager->persist($appl_inst);
 
         $appl_terms = new InstrumentTerms();
@@ -49,7 +49,7 @@ class InstrumentFixture extends Fixture implements DependentFixtureInterface
         $msft_inst->setEusipa(Instrument::EUSIPA_UNDERLYING);
         $msft_inst->setCurrency("USD");
         $msft_inst->setUnderlying($msft);
-        $appl_inst->setTaxRate(0.35);
+        $appl_inst->setExecutionTaxRate(0.0035); // 0.35 %
         $manager->persist($msft_inst);
 
         $manager->flush();

--- a/src/DataFixtures/InstrumentFixture.php
+++ b/src/DataFixtures/InstrumentFixture.php
@@ -30,6 +30,7 @@ class InstrumentFixture extends Fixture implements DependentFixtureInterface
         $appl_inst->setEusipa(Instrument::EUSIPA_KNOCKOUT);
         $appl_inst->setCurrency("EUR");
         $appl_inst->setUnderlying($appl);
+        $appl_inst->setTaxRate(0.12);
         $manager->persist($appl_inst);
 
         $appl_terms = new InstrumentTerms();
@@ -48,6 +49,7 @@ class InstrumentFixture extends Fixture implements DependentFixtureInterface
         $msft_inst->setEusipa(Instrument::EUSIPA_UNDERLYING);
         $msft_inst->setCurrency("USD");
         $msft_inst->setUnderlying($msft);
+        $appl_inst->setTaxRate(0.35);
         $manager->persist($msft_inst);
 
         $manager->flush();

--- a/src/Entity/Instrument.php
+++ b/src/Entity/Instrument.php
@@ -106,8 +106,8 @@ class Instrument
     #[ORM\Column(type: "text", length: 50000, nullable: true)]
     private $notes;
 
-    #[ORM\Column(type: "decimal", precision: 6, scale: 4, nullable: true)]
-    #[Assert\Range(min: 0.0001, max: 100)]
+    #[ORM\Column(type: "decimal", precision: 5, scale: 4, nullable: true, options: ["unsigned" => true])]
+    #[Assert\Range(min: 0, max: 1)]
     private $executionTaxRate;
 
     public function getId(): ?int

--- a/src/Entity/Instrument.php
+++ b/src/Entity/Instrument.php
@@ -108,7 +108,7 @@ class Instrument
 
     #[ORM\Column(type: "decimal", precision: 6, scale: 4, nullable: true)]
     #[Assert\Range(min: 0.0001, max: 100)]
-    private $taxRate;
+    private $executionTaxRate;
 
     public function getId(): ?int
     {
@@ -204,14 +204,14 @@ class Instrument
         return $this;
     }
 
-    public function getTaxRate(): ?string
+    public function getExecutionTaxRate(): ?string
     {
-        return $this->taxRate;
+        return $this->executionTaxRate;
     }
 
-    public function setTaxRate(?string $taxRate): self
+    public function setExecutionTaxRate(?string $executionTaxRate): self
     {
-        $this->taxRate = $taxRate;
+        $this->executionTaxRate = $executionTaxRate;
 
         return $this;
     }

--- a/src/Entity/Instrument.php
+++ b/src/Entity/Instrument.php
@@ -106,6 +106,10 @@ class Instrument
     #[ORM\Column(type: "text", length: 50000, nullable: true)]
     private $notes;
 
+    #[ORM\Column(type: "decimal", precision: 6, scale: 4, nullable: true)]
+    #[Assert\Range(min: 0.0001, max: 100)]
+    private $taxRate;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -196,6 +200,18 @@ class Instrument
     public function setNotes(?string $notes): self
     {
         $this->notes = $notes;
+
+        return $this;
+    }
+
+    public function getTaxRate(): ?string
+    {
+        return $this->taxRate;
+    }
+
+    public function setTaxRate(?string $taxRate): self
+    {
+        $this->taxRate = $taxRate;
 
         return $this;
     }

--- a/src/Form/ExecutionType.php
+++ b/src/Form/ExecutionType.php
@@ -62,6 +62,7 @@ class ExecutionType extends AbstractType
         $user = $this->token->getToken()->getUser();
 
         if ($data->instrument) {
+            $taxRate = $data->instrument->getTaxRate();
             $builder->add('instrument', TextType::class, ['disabled' =>'true']);
         } else {
             $builder->add('instrument', EntityType::class, ['class' => Instrument::class]);
@@ -109,7 +110,7 @@ class ExecutionType extends AbstractType
             ->add('execution_id', NumberType::class, ['label' => 'Execution ID', 'html5' => true, 'required' => false, 'help' => 'Execution ID used by the broker'])
             ->add('marketplace', TextType::class, ['required' => false, 'help' => 'Location of the exchange'])
             ->add('commission', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Commission cost (negative amount)'])
-            ->add('tax', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'paid tax is negative, refunded tax positive'])
+            ->add('tax', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Paid tax is negative, refunded tax positive' . (!empty($taxRate) ? ' (applying -' . $taxRate . '% of total if not provided)'  : '')])
             ->add('interest', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Paid interest (negative amount)'])
             ->add('notes', TextareaType::class, ['required' => false])
             ->add('consolidated', CheckboxType::class, ['required' => false, 'help' => 'Check if this transaction matches with your broker'])

--- a/src/Form/ExecutionType.php
+++ b/src/Form/ExecutionType.php
@@ -111,7 +111,7 @@ class ExecutionType extends AbstractType
             ->add('execution_id', NumberType::class, ['label' => 'Execution ID', 'html5' => true, 'required' => false, 'help' => 'Execution ID used by the broker'])
             ->add('marketplace', TextType::class, ['required' => false, 'help' => 'Location of the exchange'])
             ->add('commission', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Commission cost (negative amount)'])
-            ->add('tax', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Paid tax is negative, refunded tax positive' . (!empty($executionTaxRate) && !empty($direction) ? ' (applying execution tax rate -' . $executionTaxRate . '% when not provided)'  : '')])
+            ->add('tax', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Paid tax is negative, refunded tax positive' . (!empty($executionTaxRate) && !empty($direction) ? ' (applying execution tax rate of -' . $executionTaxRate * 100 . '% when empty)'  : '')])
             ->add('interest', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Paid interest (negative amount)'])
             ->add('notes', TextareaType::class, ['required' => false])
             ->add('consolidated', CheckboxType::class, ['required' => false, 'help' => 'Check if this transaction matches with your broker'])

--- a/src/Form/ExecutionType.php
+++ b/src/Form/ExecutionType.php
@@ -62,7 +62,8 @@ class ExecutionType extends AbstractType
         $user = $this->token->getToken()->getUser();
 
         if ($data->instrument) {
-            $taxRate = $data->instrument->getTaxRate();
+            $executionTaxRate = $data->instrument->getExecutionTaxRate();
+            $direction = $data->instrument->getDirection();
             $builder->add('instrument', TextType::class, ['disabled' =>'true']);
         } else {
             $builder->add('instrument', EntityType::class, ['class' => Instrument::class]);
@@ -110,7 +111,7 @@ class ExecutionType extends AbstractType
             ->add('execution_id', NumberType::class, ['label' => 'Execution ID', 'html5' => true, 'required' => false, 'help' => 'Execution ID used by the broker'])
             ->add('marketplace', TextType::class, ['required' => false, 'help' => 'Location of the exchange'])
             ->add('commission', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Commission cost (negative amount)'])
-            ->add('tax', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Paid tax is negative, refunded tax positive' . (!empty($taxRate) ? ' (applying -' . $taxRate . '% of total if not provided)'  : '')])
+            ->add('tax', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Paid tax is negative, refunded tax positive' . (!empty($executionTaxRate) && !empty($direction) ? ' (applying execution tax rate -' . $executionTaxRate . '% when not provided)'  : '')])
             ->add('interest', MoneyType::class, ['required' => false, 'html5' => false, 'currency' => $currency, 'scale' => 4, 'help' => 'Paid interest (negative amount)'])
             ->add('notes', TextareaType::class, ['required' => false])
             ->add('consolidated', CheckboxType::class, ['required' => false, 'help' => 'Check if this transaction matches with your broker'])

--- a/src/Form/InstrumentType.php
+++ b/src/Form/InstrumentType.php
@@ -90,7 +90,7 @@ class InstrumentType extends AbstractType
             ->add('terminationdate', DateType::class, ['required' => false, 'label'=>'Termination date', 'widget' => 'single_text'])
             ->add('url', UrlType::class, ['required' => false, 'label' => 'Instrument website'])
             ->add('notes', TextareaType::class, ['required' => false])
-            ->add('taxrate', TextType::class, ['required' => false, 'label'=>'Tax rate %', 'help' => 'Tax rate percentage applicable to executed trades (e.g. 0.12 %)'])
+            ->add('executiontaxrate', TextType::class, ['required' => false, 'label'=>'Execution tax rate %', 'help' => 'Tax rate percentage applicable to executed trades (e.g. 0.12% is 0.0012)'])
             ->add('save', SubmitType::class, ['label' => 'Submit', 'attr' => ['class' => 'btn btn-primary']])
             ->add('reset', ResetType::class, ['label' => 'Reset', 'attr' => ['class' => 'btn btn-secondary']])
             ->add('back', ButtonType::class, ['label' => 'Back', 'attr' => ['class' => 'btn btn-secondary']])

--- a/src/Form/InstrumentType.php
+++ b/src/Form/InstrumentType.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\ResetType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -89,6 +90,7 @@ class InstrumentType extends AbstractType
             ->add('terminationdate', DateType::class, ['required' => false, 'label'=>'Termination date', 'widget' => 'single_text'])
             ->add('url', UrlType::class, ['required' => false, 'label' => 'Instrument website'])
             ->add('notes', TextareaType::class, ['required' => false])
+            ->add('taxrate', TextType::class, ['required' => false, 'label'=>'Tax rate %', 'help' => 'Tax rate percentage applicable to executed trades (e.g. 0.12 %)'])
             ->add('save', SubmitType::class, ['label' => 'Submit', 'attr' => ['class' => 'btn btn-primary']])
             ->add('reset', ResetType::class, ['label' => 'Reset', 'attr' => ['class' => 'btn btn-secondary']])
             ->add('back', ButtonType::class, ['label' => 'Back', 'attr' => ['class' => 'btn btn-secondary']])

--- a/src/Form/Model/ExecutionFormModel.php
+++ b/src/Form/Model/ExecutionFormModel.php
@@ -104,7 +104,7 @@ class ExecutionFormModel
         }
         if ($this->tax !== null) {
             $transaction->setTax($this->tax);
-        } elseif($this->instrument->getExecutionTaxRate() != null && $this->direction != 0) {
+        } elseif($this->instrument->getExecutionTaxRate() != null && $this->direction != 0 && isset($total)) {
             // apply execution tax rate of the instrument if no tax provided in the tax field
             $transaction->setTax($this->direction * $total * $this->instrument->getExecutionTaxRate());
         } else {

--- a/src/Form/Model/ExecutionFormModel.php
+++ b/src/Form/Model/ExecutionFormModel.php
@@ -104,9 +104,9 @@ class ExecutionFormModel
         }
         if ($this->tax !== null) {
             $transaction->setTax($this->tax);
-        } elseif($this->instrument->getTaxRate() != null) {
-            // apply tax rate of the instrument if no tax provided in the form
-            $transaction->setTax($transaction->getPortfolio() * $this->instrument->getTaxRate() / 100);
+        } elseif($this->instrument->getExecutionTaxRate() != null && $this->direction != 0) {
+            // apply execution tax rate of the instrument if no tax provided in the tax field
+            $transaction->setTax($this->direction * $total * $this->instrument->getExecutionTaxRate());
         } else {
             $transaction->setTax(null);
         }

--- a/src/Form/Model/ExecutionFormModel.php
+++ b/src/Form/Model/ExecutionFormModel.php
@@ -102,8 +102,11 @@ class ExecutionFormModel
         } else {
             $transaction->setCommission(null);
         }
-        if ($this->tax) {
+        if ($this->tax !== null) {
             $transaction->setTax($this->tax);
+        } elseif($this->tax == null && $this->instrument->getTaxRate() != null) {
+            // apply tax rate of the instrument if no tax provided in the form
+            $transaction->setTax($transaction->getPortfolio() * $this->instrument->getTaxRate() / 100);
         } else {
             $transaction->setTax(null);
         }

--- a/src/Form/Model/ExecutionFormModel.php
+++ b/src/Form/Model/ExecutionFormModel.php
@@ -104,7 +104,7 @@ class ExecutionFormModel
         }
         if ($this->tax !== null) {
             $transaction->setTax($this->tax);
-        } elseif($this->tax == null && $this->instrument->getTaxRate() != null) {
+        } elseif($this->instrument->getTaxRate() != null) {
             // apply tax rate of the instrument if no tax provided in the form
             $transaction->setTax($transaction->getPortfolio() * $this->instrument->getTaxRate() / 100);
         } else {

--- a/templates/instrument/edit.html.twig
+++ b/templates/instrument/edit.html.twig
@@ -19,6 +19,7 @@
   <div class="col-md-6">{{ form_row(form.issuer) }}</div>
   <div class="col-md-6">{{ form_row(form.url) }}</div>
   <div class="col-12">{{ form_row(form.notes) }}</div>
+  <div class="col-md-4">{{ form_row(form.taxrate) }}</div>
 </div>
 
 <div>{{ form_errors(form) }}</div>

--- a/templates/instrument/edit.html.twig
+++ b/templates/instrument/edit.html.twig
@@ -19,7 +19,7 @@
   <div class="col-md-6">{{ form_row(form.issuer) }}</div>
   <div class="col-md-6">{{ form_row(form.url) }}</div>
   <div class="col-12">{{ form_row(form.notes) }}</div>
-  <div class="col-md-4">{{ form_row(form.taxrate) }}</div>
+  <div class="col-md-4">{{ form_row(form.executiontaxrate) }}</div>
 </div>
 
 <div>{{ form_errors(form) }}</div>

--- a/tests/ExecutionFormModelTest.php
+++ b/tests/ExecutionFormModelTest.php
@@ -80,7 +80,7 @@ final class ExecutionFormModelTest extends TestCase
         $data = new ExecutionFormModel();
         $data->fromExecution($execution);
         $data->populateExecution($execution);
-        $calculatedTax = $transaction->getPortfolio() * $execution->getInstrument()->getTaxRate() / 100; // -1845 * 0.12 / 100 = '-2.214'
+        $calculatedTax = is_numeric($transaction->getPortfolio()) && is_numeric($execution->getInstrument()->getTaxRate()) ? $transaction->getPortfolio() * $execution->getInstrument()->getTaxRate() / 100 : null; // -1845 * 0.12 / 100 = '-2.214'
         $this->assertSame($transaction->getTax(), strval($calculatedTax));
     }
 }


### PR DESCRIPTION
I implemented this feature to automatically pre-fill the tax field with the calculated value based on the tax rate defined in the instrument.

**How to use:**
Each instrument can have a specified tax rate percentage. When adding or editing a trade, the tax value is automatically calculated based on the defined tax rate and the total amount. If the field is manually modified, the entered tax value is retained. To disable the automatic calculation, the field must be set to 0.