### PR TITLE
Install and enable intl in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update -y && \
 RUN pecl install apcu
 RUN docker-php-ext-enable apcu
 RUN docker-php-ext-install bcmath
+RUN docker-php-ext-install intl
+RUN docker-php-ext-enable intl
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.1-cli
 LABEL maintainer Matthias Straka
 
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends unzip npm
+    apt-get install -y --no-install-recommends unzip npm libicu-dev
 
 RUN pecl install apcu
 RUN docker-php-ext-enable apcu


### PR DESCRIPTION
Added `intl` package and its dependency as it is missing when running via a docker container